### PR TITLE
Rename requirements .txt to requirements.txt

### DIFF
--- a/requirements .txt
+++ b/requirements .txt
@@ -1,1 +1,0 @@
-elasticsearch==6.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch==6.3.0


### PR DESCRIPTION
Изменено название файла. В имени был пробел, заметно на nix системах при клонировании. Возможно файл не используется и был создан для сборки контейнера.